### PR TITLE
[ANALYZER-3745] GEO Map Exclude function works incorrectly (Keep only…

### DIFF
--- a/lib/OpenLayers/Control/SelectFeature.js
+++ b/lib/OpenLayers/Control/SelectFeature.js
@@ -566,6 +566,16 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
                 minXY.lon, minXY.lat, maxXY.lon, maxXY.lat
             );
 
+          /*
+          Correct the right bound of the box if we have a negative right bound and a positive left bound (inverted bounds).
+           */
+          var correctedBounds = false;
+          var FULL_LON = 40075016.67999999;
+          if(bounds.left > 0 && bounds.right < 0) {
+            bounds.right += FULL_LON;
+            correctedBounds = true;
+          }
+
             // if multiple is false, first deselect currently selected features
             if (!this.multipleSelect()) {
                 this.unselectAll();
@@ -588,6 +598,11 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
 
                     if (this.geometryTypes == null || OpenLayers.Util.indexOf(
                             this.geometryTypes, feature.geometry.CLASS_NAME) > -1) {
+
+                        //The bounds were corrected before, if we have a negative x value need also to correct
+                        if(feature.geometry.x < 0 && correctedBounds){
+                            feature.geometry.x +=FULL_LON;
+                        }
                         if (bounds.toGeometry().intersects(feature.geometry)) {
                             if (OpenLayers.Util.indexOf(layer.selectedFeatures, feature) == -1) {
                                 this.select(feature);


### PR DESCRIPTION
… instead of Exclude)

When selecting a box that is big enough that includes a left bound with a positive geography point and right bound with a negative geography point, the intersects algorithm does not work correctly. 
The transpose of the geography point in 40075016.67999999 was taken from what was already done in BACKLOG-18225 (https://github.com/Pentaho/pentaho-platform-plugin-geo/commit/8b528b351ea5c76057b5e6a96445d87a0c46d022)

@pentaho/millenniumfalcon 
@carlosrusso 
@pentaho/tatooine 
