### PR TITLE
[BACKLOG-33095] Fix map tile images missing in Safari

### DIFF
--- a/lib/OpenLayers/Layer/OSM.js
+++ b/lib/OpenLayers/Layer/OSM.js
@@ -48,9 +48,9 @@ OpenLayers.Layer.OSM = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      * (end)
      */
     url: [
-        '//a.tile.openstreetmap.org/${z}/${x}/${y}.png',
-        '//b.tile.openstreetmap.org/${z}/${x}/${y}.png',
-        '//c.tile.openstreetmap.org/${z}/${x}/${y}.png'
+        'https://a.tile.openstreetmap.org/${z}/${x}/${y}.png',
+        'https://b.tile.openstreetmap.org/${z}/${x}/${y}.png',
+        'https://c.tile.openstreetmap.org/${z}/${x}/${y}.png'
     ],
 
     /**


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.

Merge along with: https://github.com/pentaho/ol2/pull/6