### PR TITLE
[BACKLOG-33095] Fix map tile images missing in Safari

### DIFF
--- a/lib/OpenLayers.js
+++ b/lib/OpenLayers.js
@@ -439,4 +439,4 @@
  * When asking questions or reporting issues, make sure to include the output of
  *     OpenLayers.VERSION_NUMBER in the question or issue-description.
  */
-OpenLayers.VERSION_NUMBER="Release 2.14-pentaho-R1";
+OpenLayers.VERSION_NUMBER="Release 2.14-pentaho-R2";

--- a/lib/OpenLayers/Layer/OSM.js
+++ b/lib/OpenLayers/Layer/OSM.js
@@ -48,9 +48,9 @@ OpenLayers.Layer.OSM = OpenLayers.Class(OpenLayers.Layer.XYZ, {
      * (end)
      */
     url: [
-        '//a.tile.openstreetmap.org/${z}/${x}/${y}.png',
-        '//b.tile.openstreetmap.org/${z}/${x}/${y}.png',
-        '//c.tile.openstreetmap.org/${z}/${x}/${y}.png'
+        'https://a.tile.openstreetmap.org/${z}/${x}/${y}.png',
+        'https://b.tile.openstreetmap.org/${z}/${x}/${y}.png',
+        'https://c.tile.openstreetmap.org/${z}/${x}/${y}.png'
     ],
 
     /**

--- a/lib/OpenLayers/SingleFile.js
+++ b/lib/OpenLayers/SingleFile.js
@@ -7,7 +7,7 @@ var OpenLayers = {
     /**
      * Constant: VERSION_NUMBER
      */
-    VERSION_NUMBER: "Release 2.14-pentaho-R1",
+    VERSION_NUMBER: "Release 2.14-pentaho-R2",
 
     /**
      * Constant: singleFile


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.
Merge along with: https://github.com/pentaho/ol2/pull/5